### PR TITLE
cast result to a number

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,8 @@ function acquireLock(client, lockName, timeout, retryDelay, onLockAquired) {
 
 	client.setnx(lockName, lockTimeoutValue, function(err, result) {
 		if(err) return retry();
-
+		
+		result = Number(result);
 		if(result === 0) {
 			// Lock couldn't be aquired. Check if the existing lock has timed out.
 


### PR DESCRIPTION
In version 0.10.1 of the redis client, this library is currently completely broken.  It is doing a === check on result, but result is a string '0', which causes it to always think the lock is free.