### PR TITLE
feat: add type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,4 @@
+import { RedisClientType } from 'redis';
+
+declare function redisLock(client: RedisClientType, retryDelay?: number): (lockName: string, timeout?: number) => Promise<string | undefined>;
+export = redisLock;

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "url": "git://github.com/errorception/redis-lock.git"
   },
   "main": "index.js",
+  "types": "index.d.ts",
   "engines": {
     "node": ">=12"
   },


### PR DESCRIPTION
Added TypeScript type definitions for redis-lock 1.0.0

fix: https://github.com/errorception/redis-lock/issues/36
ref: https://github.com/misskey-dev/misskey/pull/9971

The following is a record of how JSDoc handles this issue. If it is necessary, I would like to change the means of implementation.

<details>

```diff
+ /**
+  * @param {import('redis').RedisClientType} client
+  * @param {string} lockName
+  * @param {number} timeout
+  * @param {number} retryDelay
+  * @param {(timeout: number) => void} onLockAcquired
+  */
  async function acquireLock (client, lockName, timeout, retryDelay, onLockAcquired) {
```

```diff
+ /**
+  * @param {import('redis').RedisClientType} client
+  * @param {number} retryDelay
+  */
  function redisLock (client, retryDelay = DEFAULT_RETRY_DELAY) {
```

```diff
+     /**
+      * @param {string} lockName 
+      * @param {number} timeout
+      * @returns {Promise<string | undefined>}
+      */
      async function lock (lockName, timeout = DEFAULT_TIMEOUT) {
```